### PR TITLE
build: enforce Python2 for kernel build scripts

### DIFF
--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
 export ARCH=arm64
-mkdir out
+mkdir -p out
 
 BUILD_CROSS_COMPILE=$(pwd)/toolchain/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/bin/aarch64-linux-android-
 KERNEL_LLVM_BIN=$(pwd)/toolchain/llvm-arm-toolchain-ship/10.0/bin/clang
 CLANG_TRIPLE=aarch64-linux-gnu-
-KERNEL_MAKE_ENV="DTC_EXT=$(pwd)/tools/dtc CONFIG_BUILD_ARM64_DT_OVERLAY=y"
+KERNEL_MAKE_ENV="DTC_EXT=$(pwd)/tools/dtc CONFIG_BUILD_ARM64_DT_OVERLAY=y PYTHON=python2"
 
 make -j8 -C $(pwd) O=$(pwd)/out $KERNEL_MAKE_ENV ARCH=arm64 CROSS_COMPILE=$BUILD_CROSS_COMPILE REAL_CC=$KERNEL_LLVM_BIN CLANG_TRIPLE=$CLANG_TRIPLE a72q_eur_open_defconfig
 make -j8 -C $(pwd) O=$(pwd)/out $KERNEL_MAKE_ENV ARCH=arm64 CROSS_COMPILE=$BUILD_CROSS_COMPILE REAL_CC=$KERNEL_LLVM_BIN CLANG_TRIPLE=$CLANG_TRIPLE
- 
+
 cp out/arch/arm64/boot/Image $(pwd)/arch/arm64/boot/Image
+


### PR DESCRIPTION
Fix buildBuild was failing because some scripts were executed with python3 by default.
Updated build configuration to explicitly call python2 to maintain compatibility.